### PR TITLE
Fix a private-in-public error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,11 @@
 use std::io;
 use std::mem::transmute;
 
-trait AsSlice<T>: AsRef<[T]> + AsMut<[T]> {}
-impl<T, V: AsRef<[T]> + AsMut<[T]>> AsSlice<T> for V {}
+mod detail {
+    pub trait AsSlice<T>: AsRef<[T]> + AsMut<[T]> {}
+    impl<T, V: AsRef<[T]> + AsMut<[T]>> AsSlice<T> for V {}
+}
+use detail::AsSlice;
 
 /// Tranform primitive types to and from buffer.
 pub trait ByteTransform<T> {


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it was broken by a bugfix in rustc (see https://tools.taskcluster.net/task-inspector/#4gI_jCT8TWSb2wiORsIhEQ/0 and rust-lang/rust#34537 for more details).
Here's a fix.
